### PR TITLE
Ensure only one version of lets-encrypt is deployed & add the service account key to allow updating the SSL certificate in GAE settings

### DIFF
--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -29,6 +29,7 @@ CMD \
     -in gae-client-secret.json.enc \
     -out gae-client-secret.json \
     -d \
+  && cp ./gae-client-secret.json ./letsEncrypt \
   && \
     gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file gae-client-secret.json \
   && \

--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -33,6 +33,6 @@ CMD \
   && \
     gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file gae-client-secret.json \
   && \
-    gcloud app deploy letsEncrypt/app.yaml --project $PROJECT --version master \
+    (if [[ $BRANCH == 'master' ]]; then gcloud app deploy letsEncrypt/app.yaml --project $PROJECT --version master; fi) \
   && \
     gcloud app deploy app.yaml dispatch.yaml --version $BRANCH --project $PROJECT --no-promote

--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -33,6 +33,6 @@ CMD \
   && \
     gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file gae-client-secret.json \
   && \
-    gcloud app deploy letsEncrypt/app.yaml --project $PROJECT --version default \
+    gcloud app deploy letsEncrypt/app.yaml --project $PROJECT --version master \
   && \
     gcloud app deploy app.yaml dispatch.yaml --version $BRANCH --project $PROJECT --no-promote

--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -33,4 +33,6 @@ CMD \
   && \
     gcloud auth activate-service-account $SERVICE_ACCOUNT --key-file gae-client-secret.json \
   && \
-    gcloud app deploy app.yaml letsEncrypt/app.yaml dispatch.yaml --version $BRANCH --project $PROJECT --no-promote
+    gcloud app deploy letsEncrypt/app.yaml --project $PROJECT --version default \
+  && \
+    gcloud app deploy app.yaml dispatch.yaml --version $BRANCH --project $PROJECT --no-promote


### PR DESCRIPTION
This PR complements work on Let's Encrypt service. Only one version (`master`) of the service is deployed and the client secret is copied to this service to allow updating App Engine SSL settings.

This should also be merged before hollowverse/hollowverse#135