### PR TITLE
Write env.json on deploy

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -47,7 +47,7 @@ function executeCommands(commands) {
 }
 
 /**
- * Returns a function that writes a JSON file that contains various
+ * Writes a JSON file that contains various
  * information about App Engine configuration, including the branch name.
  *
  * This is working around the fact that App Engine does not provide this information
@@ -57,7 +57,7 @@ function executeCommands(commands) {
  * @param {string} path The path where the file should be written
  * @param {string} service The App Engine service name to be included in the env file
  */
-const writeEnvFile = (path, service = 'default') => () => {
+const writeEnvFile = (path, service = 'default') => {
   const env = {
     project: PROJECT,
     branch: BRANCH,
@@ -141,7 +141,7 @@ function decryptSecrets() {
 
 function main() {
   const code = executeCommands([
-    writeEnvFile('/hollowverse/env.json', 'default'),
+    () => writeEnvFile('/hollowverse/env.json', 'default'),
     'cd /hollowverse',
     decryptSecrets,
     'mv ./secrets/gcloud.letsEncrypt.json ./letsEncrypt',

--- a/deploy.js
+++ b/deploy.js
@@ -41,8 +41,8 @@ function executeCommands(commands) {
  * information about App Engine configuration, including the branch name.
  *
  * This is working around the fact that App Engine does not provide this information
- * as a environment variables for Docker-based runtimes.
- * The file should be written on CI and deploy with the app so that it can
+ * as environment variables for Docker-based runtimes.
+ * The file should be written on CI and deployed with the app so that it can
  * be accessed at runtime.
  * @param {string} path The path where the file should be written
  * @param {string} service The App Engine service name to be included in the env file

--- a/deploy.js
+++ b/deploy.js
@@ -19,7 +19,11 @@ function executeCommands(commands) {
   for (let i = 0; i < commands.length && code === 0; i++) {
     let command = commands[i];
     if (typeof command === 'function') {
+      try {
       code = command();
+      } catch (e) {
+        code = 1;
+      }
     } else {
       command = command.replace('\n', '').replace(/\s+/g, ' ').trim();
       console.info(command);

--- a/deploy.js
+++ b/deploy.js
@@ -16,7 +16,6 @@ const {
   ENC_IV_LETS_ENCRYPT_SERVICE_ACCOUNT,
   PROJECT,
   BRANCH,
-  SERVICE_ACCOUNT
 } = shelljs.env;
 
 /**
@@ -143,7 +142,7 @@ function main() {
     'cd /hollowverse',
     decryptSecrets,
     'mv ./secrets/gcloud.letsEncrypt.json ./letsEncrypt',
-    `gcloud auth activate-service-account ${SERVICE_ACCOUNT} --key-file secrets/gcloud.travis.json`,
+    `gcloud auth activate-service-account --key-file secrets/gcloud.travis.json`,
     tryDeploy,
   ]);
 

--- a/deploy.js
+++ b/deploy.js
@@ -1,4 +1,4 @@
-#! /bin/node 
+#! /bin/node
 
 // Enable TS type checker for JavaScript
 // @ts-check
@@ -62,20 +62,20 @@ const writeEnvFile = (path, service = 'default') => () => {
     project: PROJECT,
     branch: BRANCH,
     service,
-  }
+  };
 
   return fs.writeFileSync(path, JSON.stringify(env, undefined, 2));
-}
+};
 
 function deploy() {
   const commands = [];
 
   if (BRANCH === 'master') {
     commands.push(
-      `gcloud app deploy letsEncrypt/app.yaml --project ${PROJECT} --version master`
+      `gcloud app deploy letsEncrypt/app.yaml --project ${PROJECT} --version master`,
     );
   }
-  
+
   commands.push(`
     gcloud app deploy app.yaml dispatch.yaml \
     --project ${PROJECT} \
@@ -90,7 +90,7 @@ function tryDeploy(maxNumAttempts = 5) {
   let numAttempts = 0;
   let code = 1;
 
-  while (numAttempts < maxNumAttempts)  {
+  while (numAttempts < maxNumAttempts) {
     numAttempts += 1;
     console.info(`Deploying... (attempt #${numAttempts})`);
 
@@ -122,10 +122,11 @@ const secrets = [
 ];
 
 function decryptSecrets() {
-  return executeCommands(secrets.map((secret) => {
-    const { key, iv, decryptedFilename } = secret;
+  return executeCommands(
+    secrets.map(secret => {
+      const { key, iv, decryptedFilename } = secret;
 
-    return `
+      return `
       openssl aes-256-cbc \
         -K ${key} \
         -iv ${iv} \
@@ -134,7 +135,8 @@ function decryptSecrets() {
         -d \
         -base64
     `;
-  }));
+    }),
+  );
 }
 
 function main() {
@@ -152,7 +154,7 @@ function main() {
   } else {
     console.error('Failed to deploy');
   }
-  
+
   // Required to inform CI of build result
   process.exit(code);
 }

--- a/deploy.js
+++ b/deploy.js
@@ -142,7 +142,7 @@ function main() {
     writeEnvFile('/hollowverse/env.json', 'default'),
     'cd /hollowverse',
     decryptSecrets,
-    'cp ./secrets/gcloud.letsEncrypt.json ./letsEncrypt',
+    'mv ./secrets/gcloud.letsEncrypt.json ./letsEncrypt',
     `gcloud auth activate-service-account ${SERVICE_ACCOUNT} --key-file secrets/gcloud.travis.json`,
     tryDeploy,
   ]);

--- a/deploy.js
+++ b/deploy.js
@@ -131,7 +131,8 @@ function decryptSecrets() {
         -iv ${iv} \
         -in ${decryptedFilename}.enc \
         -out ${decryptedFilename} \
-        -d
+        -d \
+        -base64
     `;
   }));
 }

--- a/deploy.js
+++ b/deploy.js
@@ -20,6 +20,7 @@ function executeCommands(commands) {
     let command = commands[i];
     if (typeof command === 'function') {
       try {
+        console.info(`${command.name}()`);
       code = command();
       } catch (e) {
         code = 1;

--- a/deploy.js
+++ b/deploy.js
@@ -22,7 +22,7 @@ function executeCommands(commands) {
     if (typeof command === 'function') {
       try {
         console.info(`${command.name}()`);
-      code = command();
+        code = command();
       } catch (e) {
         code = 1;
       }
@@ -58,7 +58,6 @@ const writeEnvFile = (path, service = 'default') => () => {
 }
 
 function deploy() {
-  let code = 0;
   const commands = [];
 
   if (BRANCH === 'master') {


### PR DESCRIPTION
Working around the fact that App Engine does not provide this information as environment variables for Docker-based runtimes, this file contains information about Google App Engine configuration, including the service and branch names. The file should be written on CI and deployed with the app so that it can be accessed at runtime.

This should be merged before https://github.com/hollowverse/hollowverse/pull/143