### PR TITLE
Log errors and fix exit code

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile*
+node_modules

--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -31,6 +31,8 @@ RUN yarn
 
 ADD . .
 
+RUN mkdir /hollowverse
+
 # Decrypt the credentials we added to the repo using
 # the key we added with the Travis command line tool
 CMD node /deploy.js

--- a/deploy.js
+++ b/deploy.js
@@ -31,15 +31,26 @@ function executeCommands(commands) {
     let command = commands[i];
     if (typeof command === 'function') {
       try {
-        console.info(`${command.name}()`);
-        code = command();
+        if (command.name) {
+          console.info(`${command.name}()`);
+        }
+        code = command() || 0;
       } catch (e) {
+        console.error(e);
         code = 1;
       }
     } else {
       command = command.replace('\n', '').replace(/\s+/g, ' ').trim();
       console.info(command);
-      code = shelljs.exec(command).code;
+      const result = shelljs.exec(command);
+      const { stdout, stderr } = result;
+      code = result.code
+      if (stdout) {
+        console.info(stdout);
+      }
+      if (stderr) {
+        console.error(stderr);
+      }
     }
   }
 
@@ -153,6 +164,7 @@ function main() {
   if (code === 0) {
     console.info('App deployed successfully');
   } else {
+    console.log(code);
     console.error('Failed to deploy');
   }
 

--- a/deploy.js
+++ b/deploy.js
@@ -42,15 +42,7 @@ function executeCommands(commands) {
     } else {
       command = command.replace('\n', '').replace(/\s+/g, ' ').trim();
       console.info(command);
-      const result = shelljs.exec(command);
-      const { stdout, stderr } = result;
-      code = result.code
-      if (stdout) {
-        console.info(stdout);
-      }
-      if (stderr) {
-        console.error(stderr);
-      }
+      code = shelljs.exec(command).code;
     }
   }
 


### PR DESCRIPTION
Looking at the build logs for the latest commit (https://travis-ci.org/hollowverse/hollowverse/builds/265671876), the deploy script seems to be exiting with 0. Debugging the script locally uncovered a few issues with the `executeCommand` function where executing a JS function that does not return anything would assign `undefined` to `code`. Which means `process.exit` is called with `undefined`, which is then coerced to `0`. Normally coercing `undefined` to `0` would have the same effect, but it would not cause the loop in `executeCommands` to break because we are using strict comparisons `===`; which means it continues to go through the following commands, overwriting `code` every time.

This PR also fixes a few logging issue with anonymous functions, and adds logging for JS errors, `stderr` and `stdout` for shell commands.