### PR TITLE
Change directory using shelljs.cd

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -146,7 +146,7 @@ function decryptSecrets() {
 function main() {
   const code = executeCommands([
     () => writeEnvFile('/hollowverse/env.json', 'default'),
-    'cd /hollowverse',
+    () => shelljs.cd('/hollowverse'),
     decryptSecrets,
     'mv ./secrets/gcloud.letsEncrypt.json ./letsEncrypt',
     `gcloud auth activate-service-account --key-file secrets/gcloud.travis.json`,


### PR DESCRIPTION
Replace 'cd /hollowverse' with a call to `shelljs.cd` which changes the directory for the duration of the deploy script.