### PR TITLE
Always expect numbers as return codes in execCommands

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -151,7 +151,9 @@ function decryptSecrets() {
 function main() {
   const code = executeCommands([
     () => writeEnvFile('/hollowverse/env.json', 'default'),
-    () => shelljs.cd('/hollowverse'),
+    () => {
+      shelljs.cd('/hollowverse');
+    },
     decryptSecrets,
     'mv ./secrets/gcloud.letsEncrypt.json ./letsEncrypt',
     `gcloud auth activate-service-account --key-file secrets/gcloud.travis.json`,

--- a/deploy.js
+++ b/deploy.js
@@ -21,7 +21,7 @@ const {
 /**
  * A helper function that executes shell commands or JavaScript functions.
  * Simulates `set -e` behavior in shell, i.e. exits as soon as any commands fail
- * @param  {(string | Function)[]} commands
+ * @param  {(string | function(): (number | void))[]} commands
  * @return Exit code for the last executed command, a non-zero value indicates failure
  */
 function executeCommands(commands) {

--- a/deploy.js
+++ b/deploy.js
@@ -165,7 +165,7 @@ function main() {
     console.error('Failed to deploy');
     process.exit(1);
   }
-  
+
   // Required to inform CI of build result
   console.info('App deployed successfully');
   process.exit(0);

--- a/deploy.js
+++ b/deploy.js
@@ -34,7 +34,12 @@ function executeCommands(commands) {
         if (command.name) {
           console.info(`${command.name}()`);
         }
-        code = command() || 0;
+        const result = command();
+        if (typeof result !== 'number') {
+          code = 0;
+        } else {
+          code = result;
+        }
       } catch (e) {
         console.error(e);
         code = 1;
@@ -153,15 +158,15 @@ function main() {
     tryDeploy,
   ]);
 
-  if (code === 0) {
-    console.info('App deployed successfully');
-  } else {
+  if (code !== 0) {
     console.log(code);
     console.error('Failed to deploy');
+    process.exit(1);
   }
-
+  
   // Required to inform CI of build result
-  process.exit(code);
+  console.info('App deployed successfully');
+  process.exit(0);
 }
 
 main();


### PR DESCRIPTION
* Do not implicitly return from cd arrow function, because the return value will be an object, which is not expected as an exit code.
* Always expect numbers as return codes in `execCommands`.