### PR TITLE
Move yarn command to runtime

### DIFF
--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -31,6 +31,4 @@ WORKDIR /repo
 
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
-RUN yarn
-
-CMD node deploy.js
+CMD yarn --prod && node deploy.js


### PR DESCRIPTION
The /repo dir will be empty at build time so no dependencies will be installed.