### PR TITLE
Add git

### DIFF
--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -23,7 +23,7 @@ RUN \
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 RUN apt-get update
-RUN apt-get install google-cloud-sdk nodejs yarn -y
+RUN apt-get install google-cloud-sdk nodejs yarn git -y
 
 RUN mkdir /repo
 


### PR DESCRIPTION
git is required by yarn to install `hollowverse/common` (although I moved the package to `devDependencies` and we are using `yarn --prod`, it is still complaining that git is missing.