### PR TITLE
Replace default shell with bash, and set NODE_ENV

### DIFF
--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -40,6 +40,11 @@ RUN mkdir /repo
 
 WORKDIR /repo
 
+# Replace default shell with bash
+RUN ln -s -f /bin/bash /bin/sh
+
+ENV NODE_ENV=production
+
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
 CMD yarn --prod && node deploy.js


### PR DESCRIPTION
The default shell in ubuntu (`/bin/sh`) is very basic and does not offer the required functionality to run npm scripts located in `node_modules/.bin`, which includes all the tools required to build the project (`webpack`, `tsc`..).

We also set `NODE_ENV=production` so that we do not have to set it for every command