### PR TITLE
Unset NODE_ENV

### DIFF
--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -43,8 +43,6 @@ WORKDIR /repo
 # Replace default shell with bash
 RUN ln -s -f /bin/bash /bin/sh
 
-ENV NODE_ENV=production
-
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
-CMD yarn --prod && node deploy.js
+CMD yarn && node deploy.js


### PR DESCRIPTION
It turns out we still need dev dependencies to do the build