### PR TITLE
Remove Google Cloud SDK

### DIFF
--- a/Dockerfile-gae
+++ b/Dockerfile-gae
@@ -8,7 +8,6 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y curl lsb-release wget build-essential linux-headers-$LINUX_VERSION
 
 # Get OpenSSL 1.1.0f source, compile and install
-
 RUN wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
 RUN tar xfz ./openssl-$OPENSSL_VERSION.tar.gz
 WORKDIR /openssl-$OPENSSL_VERSION
@@ -23,18 +22,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-# Add the Cloud SDK distribution URI as a package source
-RUN \
-  export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
-  && \
-  echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | \
-    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-
-# Import the Google Cloud public key
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-
 RUN apt-get update
-RUN apt-get install google-cloud-sdk nodejs yarn git -y
+RUN apt-get install nodejs yarn git -y
 
 RUN mkdir /repo
 


### PR DESCRIPTION
We don't currently need to install the AWS EB CLI tool because:
* Elastic Beanstalk accepts ZIP files to deploy
* CodeBuild packages the build as ZIP
* CodePipeline takes the ZIP file from CodeBuild and deploys it to EB