### PR TITLE
Simplify Dockerfile and switch base image to node:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,9 @@ FROM node:alpine
 RUN apk update && apk add git py2-pip openssl
 
 # Install AWS Elastic Beanstalk CLI Tool using pip
-RUN pip install awsebcli --upgrade --user
+RUN pip install awsebcli --upgrade
 
 ENV NODE_ENV=development
-
-# Export path containing the AWS EB CLI tool
-ENV PATH=$PATH:~/.local/bin
-
-RUN mkdir /repo
 
 WORKDIR /repo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,11 @@
-FROM ubuntu:16.04
-ENV OPENSSL_VERSION=1.1.0f
-ENV LINUX_VERSION=4.11.0-14-generic
+FROM node:alpine
 
-# Install prerequisites
-RUN apt-get update -qq && apt-get upgrade -y -qq
-
-RUN apt-get install -qq -y curl lsb-release wget build-essential linux-headers-$LINUX_VERSION
-
-# Get OpenSSL 1.1.0f source, compile and install
-RUN wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
-RUN tar xfz ./openssl-$OPENSSL_VERSION.tar.gz
-WORKDIR /openssl-$OPENSSL_VERSION
-RUN ./config -Wl,--enable-new-dtags,-rpath,'$(LIBRPATH)'
-RUN make && make install
-WORKDIR /
-
-# Add Node.js source
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
-
-# Add yarn source
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-RUN apt-get update -qq
-RUN apt-get install nodejs yarn git python-pip -y -qq
+RUN apk update && apk add git py2-pip openssl
 
 # Install AWS Elastic Beanstalk CLI Tool using pip
 RUN pip install awsebcli --upgrade --user
+
+ENV NODE_ENV=development
 
 # Export path containing the AWS EB CLI tool
 ENV PATH=$PATH:~/.local/bin
@@ -34,9 +13,6 @@ ENV PATH=$PATH:~/.local/bin
 RUN mkdir /repo
 
 WORKDIR /repo
-
-# Replace default shell with bash
-RUN ln -s -f /bin/bash /bin/sh
 
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.


### PR DESCRIPTION
Alpine is a lightweight Linux distribution designed for use in containers and aims to offer the required tools and packages at the minimum size.

The official Alpine-based Node.js image is 67MB, while the default Debian-based one is a whopping 672MB. Both images provide `yarn` by default, we just need to add `git` to be able to install `@hollowverse/common`.

One caveat is that the OpenSSL version in Alpine (and also in Ubuntu) is the 1.0.2k, which is the LTS version and is still receiving security patches but the encrypted secrets in the other repos are incompatible because they were encrypted with OpenSSL 1.1.

I'd like to remove the compilation step we are currently performing in this image and re-encrypt the secrets with the LTS version instead (hollowverse/hollowverse#190, hollowverse/release-manager#7, hollowverse/hollowbot#7).

The build environment image built from this branch is 187MB and takes  2m 36s to build on my laptop. The same image built from master is 1.02GB and takes 17m 19s to build on the same laptop with equivalant cached layers!

Building this image on Travis takes 58 seconds, while the master image takes around 5 minutes usually.

This should result in significantly faster builds and, as a result, faster deployments.

This PR should be merged and built before hollowverse/hollowverse#190, hollowverse/release-manager#7 and hollowverse/hollowbot#7