### PR TITLE
Lock Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:8.9-alpine
 
 RUN apk update -q && apk add git py2-pip openssl -q
 


### PR DESCRIPTION
Enable brotli compression for static assets requires a native dependency that is not yet available precompiled for Node 9.