### PR TITLE
Add openssl-dev required for nodegit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update -q
 RUN apk add -q --no-cache git py2-pip openssl
 
 # Native dependencies required to compile some Node.js packages
-RUN apk add -q --no-cache make gcc g++ python
+RUN apk add -q --no-cache make gcc g++ python openssl-dev
 
 # Install AWS Elastic Beanstalk CLI Tool using pip
 RUN pip install awsebcli -q --upgrade


### PR DESCRIPTION
`perf-monitor` depends on `nodegit`, which requires OpenSSL native development libraries.