### PR TITLE
Use yarn in lambda image, switch from "deploy.js" to "deploy" script

### DIFF
--- a/Dockerfile-lambda
+++ b/Dockerfile-lambda
@@ -6,6 +6,10 @@ RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 
 ENV PATH="/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH"
 
+RUN node --version
+RUN npm --version
+RUN yarn --version
+
 WORKDIR /repo
 
 # Install dependencies for the mounted project, so that

--- a/Dockerfile-lambda
+++ b/Dockerfile-lambda
@@ -1,9 +1,9 @@
 FROM lambci/lambda:build-nodejs6.10
 
-RUN npm i --global @babel/core @babel/node
+RUN apk update && apk add yarn
 
 WORKDIR /repo
 
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
-CMD npm i && babel-node deploy.js
+CMD yarn && yarn deploy

--- a/Dockerfile-lambda
+++ b/Dockerfile-lambda
@@ -1,6 +1,10 @@
 FROM lambci/lambda:build-nodejs6.10
 
-RUN apk update && apk add yarn
+RUN touch ~/.profile
+
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+
+ENV PATH="/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH"
 
 WORKDIR /repo
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Any required environment variables should be defined in the project settings on 
 
 ## `Dockerfile-lambda`
 
-Similar to the regular `Dockerfile`, except that it runs Node.js 6 instead in order to emulate the AWS Lambda environment.
+Similar to the regular `Dockerfile`, except that it runs Node.js 6 instead in order to emulate the AWS Lambda environment. It also expects that you have a script in your `package.json` named `"deploy"` which performs the deployment tasks.
 
 The image can be pulled using `docker pull hollowverse/build-env:lambda`.
 
-Because version 6 of Node.js is quite outdated and lacks many of the features of JavaScript we have come to expect, we use babel to transpile the `deploy.js` file before executing it. This means that you can safely use modern JS syntax and features to write the deployment script, provided that your repository provides the required Babel configuration settings, either via a `.babelrc` file, or as a `babel` field in `package.json`. The required babel plugins must also be defined in `package.json`.
+Because version 6 of Node.js is quite outdated and lacks many of the features of JavaScript we have come to expect, you may want to use babel to transpile the deployment script file before executing it. This way, you can safely use modern JS syntax and features to write the deployment script, provided that your repository provides the required Babel packages and configuration settings. This image does not install any Babel packages for you.
 
 For an example of a repository that uses this image, check out [`perf-monitor`](https://github.com/hollowverse/perf-monitor)


### PR DESCRIPTION
This allows using `yarn.lock` even for development dependencies. Using "deploy" script instead of "deploy.js" file allows more flexibility for the deployment task entry.