### PR TITLE
Restore Lambda Node.js 6 build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,12 @@ services:
 script:
   - docker build -t hollowverse/build-env ./
   - docker build -t hollowverse/build-env:lambda ./ --file Dockerfile-lambda
+  - docker build -t hollowverse/build-env:lambda-6 ./ --file Dockerfile-lambda-6
   - if [[ ($TRAVIS_PULL_REQUEST == "false") && ($TRAVIS_BRANCH == "master") ]]; then 
-      docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}" && docker push hollowverse/build-env && docker push hollowverse/build-env:lambda;
+      docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}" && \
+      docker push hollowverse/build-env && \
+      docker push hollowverse/build-env:lambda && \
+      docker push hollowverse/build-env:lambda6;
     fi
 
 notifications:

--- a/Dockerfile-lambda-6
+++ b/Dockerfile-lambda-6
@@ -1,0 +1,17 @@
+FROM lambci/lambda:build-nodejs6.10
+
+RUN touch ~/.profile
+
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash
+
+ENV PATH="/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH"
+
+RUN node --version
+RUN npm --version
+RUN yarn --version
+
+WORKDIR /repo
+
+# Install dependencies for the mounted project, so that
+# the dependencies of the deploy script are satisfied.
+CMD yarn && yarn deploy


### PR DESCRIPTION
To be used for new builds of `lambda-assign-env`, uses a new tag `build-env:lambda-6`.