### PR TITLE
Fail if yarn.lock is not up-to-date

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR /repo
 
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
-CMD yarn && yarn deploy
+CMD yarn --frozen-lockfile && yarn deploy

--- a/Dockerfile-lambda
+++ b/Dockerfile-lambda
@@ -14,4 +14,4 @@ WORKDIR /repo
 
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
-CMD yarn && yarn deploy
+CMD yarn --frozen-lockfile && yarn deploy

--- a/Dockerfile-lambda-6
+++ b/Dockerfile-lambda-6
@@ -14,4 +14,4 @@ WORKDIR /repo
 
 # Install dependencies for the mounted project, so that
 # the dependencies of the deploy script are satisfied.
-CMD yarn && yarn deploy
+CMD yarn --frozen-lockfile && yarn deploy


### PR DESCRIPTION
With clown updating our `package.json` files, it's easy to forget to run `yarn` after `package.json` is updated. This means that `yarn.lock` could go out of sync with `package.json` so we might get some dependencies that are not locked. `--frozen-lockfile` fails the build if that is the case.