### PR TITLE
Add FORCE_COLOR env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add -q --no-cache make gcc g++ python openssl-dev curl-dev
 RUN pip install awsebcli -q --upgrade
 
 ENV NODE_ENV=development
+ENV FORCE_COLOR=true
 
 WORKDIR /repo
 

--- a/Dockerfile-lambda
+++ b/Dockerfile-lambda
@@ -5,6 +5,8 @@ RUN touch ~/.profile
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 
 ENV PATH="/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH"
+ENV NODE_ENV=development
+ENV FORCE_COLOR=true
 
 RUN node --version
 RUN npm --version

--- a/Dockerfile-lambda-6
+++ b/Dockerfile-lambda-6
@@ -5,6 +5,8 @@ RUN touch ~/.profile
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash
 
 ENV PATH="/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH"
+ENV NODE_ENV=development
+ENV FORCE_COLOR=true
 
 RUN node --version
 RUN npm --version


### PR DESCRIPTION
This is used by [chalk](https://github.com/chalk/chalk) (which lots of JS tools use to print to the shell). This should enable color output for Jest tests without having to pass `--color` and many other tools.